### PR TITLE
Finalisation reprise de stock carte*prix + Facture uniquement reprise…

### DIFF
--- a/components/global-invoice-dialog.tsx
+++ b/components/global-invoice-dialog.tsx
@@ -286,13 +286,15 @@ export function GlobalInvoiceDialog({
       const adjustmentRows = (adjustments || []).map((adj) => {
         const amt = Number(adj.amount);
         const amtStr = (isNaN(amt) ? '0.00' : amt.toFixed(2)) + ' €';
+        const quantity = adj.quantity || '';
+        const unitPrice = adj.unit_price ? (Number(adj.unit_price).toFixed(2) + ' €') : '';
         return [
           adj.operation_name || 'Ajustement',
           '',
           '',
           '',
-          '',
-          '',
+          quantity.toString(),
+          unitPrice,
           amtStr
         ];
       });

--- a/components/stock-update-confirmation-dialog.tsx
+++ b/components/stock-update-confirmation-dialog.tsx
@@ -18,11 +18,18 @@ interface CollectionUpdate {
   isCustomPrice: boolean;
 }
 
+interface PendingAdjustment {
+  operation_name: string;
+  unit_price: string;
+  quantity: string;
+}
+
 interface StockUpdateConfirmationDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onConfirm: () => void;
   collectionUpdates: CollectionUpdate[];
+  pendingAdjustments?: PendingAdjustment[];
   loading?: boolean;
 }
 
@@ -31,10 +38,21 @@ export function StockUpdateConfirmationDialog({
   onOpenChange,
   onConfirm,
   collectionUpdates,
+  pendingAdjustments = [],
   loading = false
 }: StockUpdateConfirmationDialogProps) {
   const totalCardsSold = collectionUpdates.reduce((sum, item) => sum + item.cardsSold, 0);
-  const totalAmount = collectionUpdates.reduce((sum, item) => sum + item.amount, 0);
+  const collectionsAmount = collectionUpdates.reduce((sum, item) => sum + item.amount, 0);
+  
+  // Calcul du total des ajustements (reprises de stock)
+  const adjustmentsTotal = pendingAdjustments.reduce((sum, adj) => {
+    const unitPrice = parseFloat(adj.unit_price);
+    const quantity = parseInt(adj.quantity);
+    if (isNaN(unitPrice) || isNaN(quantity)) return sum;
+    return sum + (unitPrice * quantity);
+  }, 0);
+  
+  const totalAmount = collectionsAmount + adjustmentsTotal;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -57,73 +75,119 @@ export function StockUpdateConfirmationDialog({
               <p className="text-3xl font-bold text-orange-900">{totalCardsSold}</p>
             </div>
 
-            <div className="bg-green-50 rounded-lg p-4 border border-green-100">
-              <div className="flex items-center gap-2 text-green-600 mb-2">
+            <div className={`rounded-lg p-4 border ${totalAmount < 0 ? 'bg-red-50 border-red-100' : 'bg-green-50 border-green-100'}`}>
+              <div className={`flex items-center gap-2 mb-2 ${totalAmount < 0 ? 'text-red-600' : 'text-green-600'}`}>
                 <Euro className="h-5 w-5" />
                 <span className="text-sm font-medium">Montant total</span>
               </div>
-              <p className="text-3xl font-bold text-green-900">{totalAmount.toFixed(2)} €</p>
+              <p className={`text-3xl font-bold ${totalAmount < 0 ? 'text-red-900' : 'text-green-900'}`}>
+                {totalAmount.toFixed(2)} €
+              </p>
             </div>
           </div>
 
           <Separator />
 
           {/* Collection details */}
-          <div>
-            <h3 className="font-semibold text-slate-900 mb-4 flex items-center gap-2">
-              <Package className="h-5 w-5" />
-              Détail par collection
-            </h3>
-            <div className="space-y-3">
-              {collectionUpdates.map((update, index) => (
-                <div
-                  key={index}
-                  className="border border-slate-200 rounded-lg p-4 bg-white"
-                >
-                  <div className="flex justify-between items-start mb-3">
-                    <div>
-                      <p className="font-semibold text-slate-900">{update.collection.name}</p>
-                      <p className="text-sm text-slate-500">
-                        Prix unitaire : {update.effectivePrice.toFixed(2)} €
-                        {update.isCustomPrice && <span className="ml-1 text-blue-600">(personnalisé)</span>}
-                      </p>
-                    </div>
-                    <div className="text-right">
-                      <p className="text-sm text-slate-500">Montant</p>
-                      <p className="text-xl font-bold text-slate-900">
-                        {update.amount.toFixed(2)} €
-                      </p>
-                    </div>
-                  </div>
+          {collectionUpdates.length > 0 && (
+            <>
+              <div>
+                <h3 className="font-semibold text-slate-900 mb-4 flex items-center gap-2">
+                  <Package className="h-5 w-5" />
+                  Détail par collection
+                </h3>
+                <div className="space-y-3">
+                  {collectionUpdates.map((update, index) => (
+                    <div
+                      key={index}
+                      className="border border-slate-200 rounded-lg p-4 bg-white"
+                    >
+                      <div className="flex justify-between items-start mb-3">
+                        <div>
+                          <p className="font-semibold text-slate-900">{update.collection.name}</p>
+                          <p className="text-sm text-slate-500">
+                            Prix unitaire : {update.effectivePrice.toFixed(2)} €
+                            {update.isCustomPrice && <span className="ml-1 text-blue-600">(personnalisé)</span>}
+                          </p>
+                        </div>
+                        <div className="text-right">
+                          <p className="text-sm text-slate-500">Montant</p>
+                          <p className="text-xl font-bold text-slate-900">
+                            {update.amount.toFixed(2)} €
+                          </p>
+                        </div>
+                      </div>
 
-                  <div className="grid grid-cols-2 md:grid-cols-5 gap-3 text-sm">
-                    <div>
-                      <span className="text-slate-500 block mb-1">Stock précédent</span>
-                      <span className="font-semibold">{update.previousStock}</span>
+                      <div className="grid grid-cols-2 md:grid-cols-5 gap-3 text-sm">
+                        <div>
+                          <span className="text-slate-500 block mb-1">Stock précédent</span>
+                          <span className="font-semibold">{update.previousStock}</span>
+                        </div>
+                        <div>
+                          <span className="text-slate-500 block mb-1">Stock compté</span>
+                          <span className="font-semibold">{update.countedStock}</span>
+                        </div>
+                        <div>
+                          <span className="text-slate-500 block mb-1">Cartes vendues</span>
+                          <span className="font-semibold text-orange-600">{update.cardsSold}</span>
+                        </div>
+                        <div>
+                          <span className="text-slate-500 block mb-1">Nouveau dépôt</span>
+                          <span className="font-semibold text-blue-600">{update.newStock}</span>
+                        </div>
+                        <div>
+                          <span className="text-slate-500 block mb-1">Cartes ajoutées</span>
+                          <span className="font-semibold text-green-600">+{update.cardsAdded}</span>
+                        </div>
+                      </div>
                     </div>
-                    <div>
-                      <span className="text-slate-500 block mb-1">Stock compté</span>
-                      <span className="font-semibold">{update.countedStock}</span>
-                    </div>
-                    <div>
-                      <span className="text-slate-500 block mb-1">Cartes vendues</span>
-                      <span className="font-semibold text-orange-600">{update.cardsSold}</span>
-                    </div>
-                    <div>
-                      <span className="text-slate-500 block mb-1">Nouveau dépôt</span>
-                      <span className="font-semibold text-blue-600">{update.newStock}</span>
-                    </div>
-                    <div>
-                      <span className="text-slate-500 block mb-1">Cartes ajoutées</span>
-                      <span className="font-semibold text-green-600">+{update.cardsAdded}</span>
-                    </div>
-                  </div>
+                  ))}
                 </div>
-              ))}
-            </div>
-          </div>
+              </div>
+              <Separator />
+            </>
+          )}
 
-          <Separator />
+          {/* Adjustments (reprises de stock) */}
+          {pendingAdjustments.length > 0 && (
+            <>
+              <div>
+                <h3 className="font-semibold text-slate-900 mb-4 flex items-center gap-2">
+                  <TrendingDown className="h-5 w-5 text-red-600" />
+                  Reprises de stock
+                </h3>
+                <div className="space-y-3">
+                  {pendingAdjustments.map((adj, index) => {
+                    const unitPrice = parseFloat(adj.unit_price);
+                    const quantity = parseInt(adj.quantity);
+                    const total = unitPrice * quantity;
+                    return (
+                      <div
+                        key={index}
+                        className="border border-red-200 rounded-lg p-4 bg-red-50"
+                      >
+                        <div className="flex justify-between items-start mb-2">
+                          <div>
+                            <p className="font-semibold text-slate-900">{adj.operation_name}</p>
+                            <p className="text-sm text-slate-600 mt-1">
+                              {quantity} carte{quantity > 1 ? 's' : ''} × {unitPrice.toFixed(2)} €
+                            </p>
+                          </div>
+                          <div className="text-right">
+                            <p className="text-sm text-slate-500">Montant</p>
+                            <p className="text-xl font-bold text-red-700">
+                              {total.toFixed(2)} €
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+              <Separator />
+            </>
+          )}
 
           {/* Total summary */}
           <div className="bg-slate-50 rounded-lg p-6 border border-slate-200">
@@ -132,18 +196,40 @@ export function StockUpdateConfirmationDialog({
               Récapitulatif de facturation
             </h3>
             <div className="space-y-3">
-              <div className="flex justify-between items-center text-slate-700">
-                <span>Nombre de collections mises à jour</span>
-                <span className="font-medium">{collectionUpdates.length}</span>
-              </div>
-              <div className="flex justify-between items-center text-slate-700">
-                <span>Total cartes vendues</span>
-                <span className="font-medium">{totalCardsSold}</span>
-              </div>
+              {collectionUpdates.length > 0 && (
+                <>
+                  <div className="flex justify-between items-center text-slate-700">
+                    <span>Nombre de collections mises à jour</span>
+                    <span className="font-medium">{collectionUpdates.length}</span>
+                  </div>
+                  <div className="flex justify-between items-center text-slate-700">
+                    <span>Total cartes vendues</span>
+                    <span className="font-medium">{totalCardsSold}</span>
+                  </div>
+                  <div className="flex justify-between items-center text-slate-700">
+                    <span>Montant ventes</span>
+                    <span className="font-medium">{collectionsAmount.toFixed(2)} €</span>
+                  </div>
+                </>
+              )}
+              {pendingAdjustments.length > 0 && (
+                <>
+                  <div className="flex justify-between items-center text-slate-700">
+                    <span>Nombre de reprises de stock</span>
+                    <span className="font-medium">{pendingAdjustments.length}</span>
+                  </div>
+                  <div className="flex justify-between items-center text-red-700">
+                    <span>Montant reprises</span>
+                    <span className="font-medium">{adjustmentsTotal.toFixed(2)} €</span>
+                  </div>
+                </>
+              )}
               <Separator />
               <div className="flex justify-between items-center pt-2">
                 <span className="text-xl font-bold text-slate-900">Montant total à facturer</span>
-                <span className="text-3xl font-bold text-slate-900">{totalAmount.toFixed(2)} €</span>
+                <span className={`text-3xl font-bold ${totalAmount < 0 ? 'text-red-700' : 'text-slate-900'}`}>
+                  {totalAmount.toFixed(2)} €
+                </span>
               </div>
             </div>
           </div>

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -66,6 +66,8 @@ export type InvoiceAdjustment = {
   invoice_id: string;
   operation_name: string;
   amount: number;
+  unit_price?: number | null;
+  quantity?: number | null;
   created_at: string;
 };
 

--- a/supabase/migrations/20251019000000_add_unit_price_quantity_to_adjustments.sql
+++ b/supabase/migrations/20251019000000_add_unit_price_quantity_to_adjustments.sql
@@ -1,0 +1,17 @@
+/*
+  # Ajout de prix unitaire et quantité aux ajustements de facture
+
+  Ajoute les colonnes unit_price et quantity à la table invoice_adjustments
+  pour permettre un calcul détaillé des reprises de stock
+*/
+
+-- Ajouter les nouvelles colonnes
+ALTER TABLE invoice_adjustments
+  ADD COLUMN IF NOT EXISTS unit_price numeric(10, 2),
+  ADD COLUMN IF NOT EXISTS quantity integer;
+
+-- Mettre à jour les commentaires
+COMMENT ON COLUMN invoice_adjustments.unit_price IS 'Prix unitaire de la carte reprise';
+COMMENT ON COLUMN invoice_adjustments.quantity IS 'Nombre de cartes reprises';
+COMMENT ON COLUMN invoice_adjustments.amount IS 'Montant total = unit_price * quantity (peut être négatif)';
+


### PR DESCRIPTION
	• Ajouter Prix carte, Nb de cartes pour reprise stock : 
		○ Modifier l'ajout d'une reprise de stock : 
			§ Au lieu de demander uniquement le montant de la reprise de stock, demander le prix par carte reprise et le nombre de cartes reprises. Le montant total de la reprise de stock sera donc : nombre de cartes reprises* prix unitaire de la carte. 
			§ Dans la facture, modifier la ligne de reprise de stock : Renseigner la colonne "Total vendu" (nombre de cartes reprises), la colonne "Prix à l'unité" (prix unitaire de la carte), et le prix TOTAL HT. 
	• Mettre l'onglet "Reprise de stock" entre collections liées et mise à jour de stock. 
Visuellement, dans la page "clients", déplacer l'encart "Reprise de stock" juste au-dessus de l'encart "Mise à jour du stock" 