### PR TITLE
Ajout du prix de vente conseillÃ© (TTC) aux collections

### DIFF
--- a/app/clients/[id]/page.tsx
+++ b/app/clients/[id]/page.tsx
@@ -83,11 +83,15 @@ export default function ClientDetailPage() {
     initial_stock: string;
     price_type: 'default' | 'custom';
     custom_price: string;
+    recommended_sale_price_type: 'default' | 'custom';
+    custom_recommended_sale_price: string;
   }>({
     collection_id: null,
     initial_stock: '',
     price_type: 'default',
-    custom_price: ''
+    custom_price: '',
+    recommended_sale_price_type: 'default',
+    custom_recommended_sale_price: ''
   });
   
   // Combobox state for collection selector
@@ -741,6 +745,17 @@ export default function ClientDetailPage() {
       customPrice = parsedPrice;
     }
 
+    // Validate custom recommended sale price if selected
+    let customRecommendedSalePrice: number | null = null;
+    if (associateForm.recommended_sale_price_type === 'custom') {
+      const parsedRecommendedSalePrice = parseFloat(associateForm.custom_recommended_sale_price);
+      if (isNaN(parsedRecommendedSalePrice) || parsedRecommendedSalePrice < 0) {
+        toast.error('Le prix de vente conseillé personnalisé doit être un nombre positif');
+        return;
+      }
+      customRecommendedSalePrice = parsedRecommendedSalePrice;
+    }
+
     try {
       const insertData: any = {
         client_id: clientId,
@@ -752,6 +767,11 @@ export default function ClientDetailPage() {
       // Only set custom_price if it's a custom price
       if (customPrice !== null) {
         insertData.custom_price = customPrice;
+      }
+
+      // Only set custom_recommended_sale_price if it's a custom price
+      if (customRecommendedSalePrice !== null) {
+        insertData.custom_recommended_sale_price = customRecommendedSalePrice;
       }
 
       const { data, error } = await supabase
@@ -770,7 +790,14 @@ export default function ClientDetailPage() {
       if (clientUpdateError) throw clientUpdateError;
 
       toast.success('Collection associée au client');
-      setAssociateForm({ collection_id: null, initial_stock: '', price_type: 'default', custom_price: '' });
+      setAssociateForm({ 
+        collection_id: null, 
+        initial_stock: '', 
+        price_type: 'default', 
+        custom_price: '',
+        recommended_sale_price_type: 'default',
+        custom_recommended_sale_price: ''
+      });
       await loadClientData();
     } catch (err) {
       console.error('Error associating collection:', err);
@@ -1033,7 +1060,7 @@ export default function ClientDetailPage() {
                 </div>
 
                 <div className="space-y-3 border border-slate-200 rounded-lg p-4 bg-slate-50">
-                  <Label>Prix de la collection</Label>
+                  <Label>Prix de cession (HT)</Label>
                   <RadioGroup
                     value={associateForm.price_type}
                     onValueChange={(val: 'default' | 'custom') => setAssociateForm(a => ({ ...a, price_type: val }))}
@@ -1080,6 +1107,59 @@ export default function ClientDetailPage() {
                   )}
                 </div>
 
+                <div className="space-y-3 border border-slate-200 rounded-lg p-4 bg-slate-50">
+                  <Label>Prix de vente conseillé (TTC)</Label>
+                  <RadioGroup
+                    value={associateForm.recommended_sale_price_type}
+                    onValueChange={(val: 'default' | 'custom') => setAssociateForm(a => ({ ...a, recommended_sale_price_type: val }))}
+                  >
+                    <div className="flex items-center space-x-2">
+                      <RadioGroupItem value="default" id="recommended-price-default" />
+                      <Label htmlFor="recommended-price-default" className="font-normal cursor-pointer">
+                        Utiliser le prix par défaut
+                        {associateForm.collection_id && allCollections.find(c => c.id === associateForm.collection_id) && (
+                          <span className="ml-2 text-sm text-slate-600">
+                            ({(() => {
+                              const collection = allCollections.find(c => c.id === associateForm.collection_id);
+                              return collection?.recommended_sale_price 
+                                ? `${collection.recommended_sale_price.toFixed(2)} €`
+                                : 'Non défini';
+                            })()})
+                          </span>
+                        )}
+                      </Label>
+                    </div>
+                    <div className="flex items-center space-x-2">
+                      <RadioGroupItem value="custom" id="recommended-price-custom" />
+                      <Label htmlFor="recommended-price-custom" className="font-normal cursor-pointer">
+                        Définir un prix spécifique pour ce client
+                      </Label>
+                    </div>
+                  </RadioGroup>
+
+                  {associateForm.recommended_sale_price_type === 'custom' && (
+                    <div className="pt-2">
+                      <Label htmlFor="custom-recommended-price">Prix personnalisé (€)</Label>
+                      <Input
+                        id="custom-recommended-price"
+                        type="text"
+                        inputMode="decimal"
+                        value={associateForm.custom_recommended_sale_price}
+                        onChange={(e) => {
+                          const value = e.target.value;
+                          // N'accepter que les nombres et le point décimal
+                          if (value === '' || /^\d*\.?\d*$/.test(value)) {
+                            setAssociateForm(a => ({ ...a, custom_recommended_sale_price: value }));
+                          }
+                        }}
+                        onWheel={(e) => e.currentTarget.blur()}
+                        placeholder="Ex: 3.00"
+                        className="mt-1.5"
+                      />
+                    </div>
+                  )}
+                </div>
+
                 <div>
                   <Button type="submit" className="w-full md:w-auto">Associer la collection</Button>
                 </div>
@@ -1094,19 +1174,22 @@ export default function ClientDetailPage() {
                   <Table>
                     <TableHeader>
                       <TableRow className="bg-slate-50">
-                        <TableHead className="w-[18%] font-semibold">Collection</TableHead>
-                        <TableHead className="w-[12%] font-semibold">Ancien dépôt</TableHead>
-                        <TableHead className="w-[14%] font-semibold">Stock compté</TableHead>
-                        <TableHead className="w-[14%] font-semibold">Nouveau dépôt</TableHead>
-                        <TableHead className="w-[24%] font-semibold">Info collection pour facture</TableHead>
-                        <TableHead className="w-[10%] text-right font-semibold">Prix</TableHead>
-                        <TableHead className="w-[8%] text-right font-semibold">Actions</TableHead>
+                        <TableHead className="w-[15%] font-semibold">Collection</TableHead>
+                        <TableHead className="w-[10%] font-semibold">Ancien dépôt</TableHead>
+                        <TableHead className="w-[12%] font-semibold">Stock compté</TableHead>
+                        <TableHead className="w-[12%] font-semibold">Nouveau dépôt</TableHead>
+                        <TableHead className="w-[20%] font-semibold">Info collection pour facture</TableHead>
+                        <TableHead className="w-[10%] text-right font-semibold">Prix de cession (HT)</TableHead>
+                        <TableHead className="w-[10%] text-right font-semibold">Prix de vente conseillé (TTC)</TableHead>
+                        <TableHead className="w-[11%] text-right font-semibold">Actions</TableHead>
                       </TableRow>
                     </TableHeader>
                     <TableBody>
                       {clientCollections.map((cc) => {
                         const effectivePrice = cc.custom_price ?? cc.collection?.price ?? 0;
                         const isCustomPrice = cc.custom_price !== null;
+                        const effectiveRecommendedSalePrice = cc.custom_recommended_sale_price ?? cc.collection?.recommended_sale_price ?? null;
+                        const isCustomRecommendedSalePrice = cc.custom_recommended_sale_price !== null;
                         
                         return (
                           <TableRow key={cc.id} className="hover:bg-slate-50/50">
@@ -1167,6 +1250,23 @@ export default function ClientDetailPage() {
                                 )}
                                 {!isCustomPrice && cc.collection?.price != null && (
                                   <p className="text-xs text-slate-500">Par défaut</p>
+                                )}
+                              </div>
+                            </TableCell>
+                            <TableCell className="align-top py-3 text-right">
+                              <div>
+                                {effectiveRecommendedSalePrice !== null ? (
+                                  <>
+                                    <p className="text-sm font-medium text-slate-900">{effectiveRecommendedSalePrice.toFixed(2)} €</p>
+                                    {isCustomRecommendedSalePrice && (
+                                      <p className="text-xs text-blue-600">Personnalisé</p>
+                                    )}
+                                    {!isCustomRecommendedSalePrice && (
+                                      <p className="text-xs text-slate-500">Par défaut</p>
+                                    )}
+                                  </>
+                                ) : (
+                                  <p className="text-xs text-slate-400">Non défini</p>
                                 )}
                               </div>
                             </TableCell>

--- a/app/collections/[id]/page.tsx
+++ b/app/collections/[id]/page.tsx
@@ -22,6 +22,7 @@ export default function CollectionDetailPage() {
   const [formData, setFormData] = useState({
     name: '',
     price: '',
+    recommended_sale_price: '',
     barcode: ''
   });
 
@@ -49,6 +50,7 @@ export default function CollectionDetailPage() {
       setFormData({
         name: collectionData.name,
         price: collectionData.price.toString(),
+        recommended_sale_price: collectionData.recommended_sale_price?.toString() || '',
         barcode: collectionData.barcode || ''
       });
     } catch (error) {
@@ -74,6 +76,13 @@ export default function CollectionDetailPage() {
         return;
       }
 
+      const recommendedSalePrice = formData.recommended_sale_price ? parseFloat(formData.recommended_sale_price) : null;
+      if (recommendedSalePrice !== null && (isNaN(recommendedSalePrice) || recommendedSalePrice < 0)) {
+        toast.error('Le prix de vente conseillé doit être un nombre positif');
+        setSubmitting(false);
+        return;
+      }
+
       // Validation du code barre s'il est renseigné
       if (formData.barcode && !/^\d{13}$/.test(formData.barcode)) {
         toast.error('Le code barre doit contenir exactement 13 chiffres');
@@ -86,6 +95,7 @@ export default function CollectionDetailPage() {
         .update({
           name: formData.name,
           price: price,
+          recommended_sale_price: recommendedSalePrice,
           barcode: formData.barcode || null,
           updated_at: new Date().toISOString()
         })
@@ -202,7 +212,7 @@ export default function CollectionDetailPage() {
                 <div className="bg-green-50 rounded-lg p-4 border border-green-100">
                   <div className="flex items-center gap-2 text-green-600 mb-2">
                     <Euro className="h-5 w-5" />
-                    <span className="text-sm font-medium">Prix de la collection</span>
+                    <span className="text-sm font-medium">Prix de cession (HT)</span>
                   </div>
                   <p className="text-3xl font-bold text-green-900">{collection.price.toFixed(2)} €</p>
                 </div>
@@ -247,7 +257,7 @@ export default function CollectionDetailPage() {
                   </div>
 
                   <div>
-                    <Label htmlFor="price">Prix de la collection (€)</Label>
+                    <Label htmlFor="price">Prix de cession (HT)</Label>
                     <Input
                       id="price"
                       type="number"
@@ -259,6 +269,21 @@ export default function CollectionDetailPage() {
                       placeholder="Ex: 2.50"
                       className="mt-1.5"
                     />
+                  </div>
+
+                  <div>
+                    <Label htmlFor="recommended_sale_price">Prix de vente conseillé (TTC)</Label>
+                    <Input
+                      id="recommended_sale_price"
+                      type="number"
+                      step="0.01"
+                      min="0"
+                      value={formData.recommended_sale_price}
+                      onChange={(e) => setFormData({ ...formData, recommended_sale_price: e.target.value })}
+                      placeholder="Ex: 3.00"
+                      className="mt-1.5"
+                    />
+                    <p className="text-xs text-slate-500 mt-1">Optionnel</p>
                   </div>
 
                   <div>

--- a/app/collections/page.tsx
+++ b/app/collections/page.tsx
@@ -19,6 +19,7 @@ export default function CollectionsPage() {
   const [formData, setFormData] = useState({
     name: '',
     price: '',
+    recommended_sale_price: '',
     barcode: ''
   });
   const [submitting, setSubmitting] = useState(false);
@@ -64,11 +65,19 @@ export default function CollectionsPage() {
         return;
       }
 
+      const recommendedSalePrice = formData.recommended_sale_price ? parseFloat(formData.recommended_sale_price) : null;
+      if (recommendedSalePrice !== null && (isNaN(recommendedSalePrice) || recommendedSalePrice < 0)) {
+        toast.error('Le prix de vente conseillé doit être un nombre positif');
+        setSubmitting(false);
+        return;
+      }
+
       const { data, error } = await supabase
         .from('collections')
         .insert([{
           name: formData.name,
           price: price,
+          recommended_sale_price: recommendedSalePrice,
           barcode: formData.barcode || null
         }])
         .select()
@@ -79,7 +88,7 @@ export default function CollectionsPage() {
       toast.success('Collection ajoutée avec succès');
       setCollections([data, ...collections]);
       setDialogOpen(false);
-      setFormData({ name: '', price: '', barcode: '' });
+      setFormData({ name: '', price: '', recommended_sale_price: '', barcode: '' });
     } catch (error) {
       console.error('Error creating collection:', error);
       toast.error('Erreur lors de la création de la collection');
@@ -135,7 +144,7 @@ export default function CollectionsPage() {
                       />
                     </div>
                     <div>
-                      <Label htmlFor="price">Prix de la collection (€)</Label>
+                      <Label htmlFor="price">Prix de cession (HT)</Label>
                       <Input
                         id="price"
                         type="number"
@@ -147,6 +156,20 @@ export default function CollectionsPage() {
                         placeholder="Ex: 2.50"
                         className="mt-1.5"
                       />
+                    </div>
+                    <div>
+                      <Label htmlFor="recommended_sale_price">Prix de vente conseillé (TTC)</Label>
+                      <Input
+                        id="recommended_sale_price"
+                        type="number"
+                        step="0.01"
+                        min="0"
+                        value={formData.recommended_sale_price}
+                        onChange={(e) => setFormData({ ...formData, recommended_sale_price: e.target.value })}
+                        placeholder="Ex: 3.00"
+                        className="mt-1.5"
+                      />
+                      <p className="text-xs text-slate-500 mt-1">Optionnel</p>
                     </div>
                     <div>
                       <Label htmlFor="barcode">Code Barre Produit (optionnel)</Label>

--- a/components/deposit-slip-dialog.tsx
+++ b/components/deposit-slip-dialog.tsx
@@ -288,38 +288,73 @@ export function DepositSlipDialog({
       doc.text('Bon de dépôt', pageWidth / 2, yPosition, { align: 'center' });
       yPosition += 10;
 
-      // 3) Tableau des collections (seulement Collection, Infos, Marchandise remise)
+      // 3) Tableau des collections (Collection, Infos, Prix de cession (HT), Prix de vente conseillé (TTC), Marchandise remise)
       const tableData = clientCollections.map((cc) => {
         const collectionName = cc.collection?.name || 'Collection';
         const info = collectionInfos[cc.collection_id || ''] || '';
+        const effectivePrice = cc.custom_price ?? cc.collection?.price ?? 0;
+        const effectiveRecommendedSalePrice = cc.custom_recommended_sale_price ?? cc.collection?.recommended_sale_price ?? null;
         const stock = cc.current_stock.toString();
         
         return [
           collectionName,
           info,
+          `${effectivePrice.toFixed(2)} €`,
+          effectiveRecommendedSalePrice !== null ? `${effectiveRecommendedSalePrice.toFixed(2)} €` : '-',
           stock
         ];
       });
 
+      // Calculer la largeur disponible pour le tableau (en tenant compte des marges)
+      const marginLeft = 15;
+      const marginRight = 15;
+      const tableWidth = pageWidth - marginLeft - marginRight;
+
+      // Définir les largeurs des colonnes : les 3 dernières colonnes doivent avoir exactement 10% chacune
+      // Collection: 35%, Infos: 35%, Prix cession HT: 10%, Prix vente conseillé TTC: 10%, Marchandise: 10%
+      const columnWidths = [
+        tableWidth * 0.35,  // Collection - 35%
+        tableWidth * 0.35,  // Infos - 35%
+        tableWidth * 0.10,  // Prix de cession (HT) - 10% (exact)
+        tableWidth * 0.10,  // Prix de vente conseillé (TTC) - 10% (exact, même taille que précédent)
+        tableWidth * 0.10   // Marchandise remise - 10% (exact, même taille que les deux précédentes)
+      ];
+
       autoTable(doc, {
         startY: yPosition,
-        head: [['Collection', 'Infos', 'Marchandise remise']],
+        head: [[
+          'Collection', 
+          'Infos', 
+          { content: 'Prix de\ncession\n(HT)', styles: { halign: 'center', valign: 'middle', fontSize: 7 } }, 
+          { content: 'Prix de vente\nconseillé\n(TTC)', styles: { halign: 'center', valign: 'middle', fontSize: 7 } }, 
+          { content: 'Marchandise\nremise', styles: { halign: 'center', valign: 'middle', fontSize: 7 } }
+        ]],
         body: tableData,
         theme: 'grid',
+        columnWidths: columnWidths,
+        tableWidth: tableWidth,
+        margin: { left: marginLeft, right: marginRight },
         headStyles: {
           fillColor: [71, 85, 105],
           textColor: 255,
-          fontSize: 9,
+          fontSize: 7,
           fontStyle: 'bold',
-          halign: 'center'
+          halign: 'center',
+          valign: 'middle',
+          cellPadding: 2,
+          overflow: 'linebreak'
         },
         bodyStyles: {
-          fontSize: 9
+          fontSize: 8,
+          cellPadding: 2,
+          overflow: 'linebreak'
         },
         columnStyles: {
           0: { halign: 'left' },
-          1: { halign: 'left', fontSize: 8 },
-          2: { halign: 'center' }
+          1: { halign: 'left', fontSize: 7 },
+          2: { halign: 'center', fontSize: 7 }, // 10% - Prix de cession HT
+          3: { halign: 'center', fontSize: 7 }, // 10% - Prix de vente conseillé TTC
+          4: { halign: 'center', fontSize: 8 }  // 10% - Marchandise remise
         }
       });
 

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -87,6 +87,7 @@ export type Collection = {
   id: string;
   name: string;
   price: number;
+  recommended_sale_price: number | null;
   barcode: string | null;
   created_at: string;
   updated_at: string;
@@ -99,6 +100,7 @@ export type ClientCollection = {
   initial_stock: number;
   current_stock: number;
   custom_price: number | null;
+  custom_recommended_sale_price: number | null;
   created_at: string;
   updated_at: string;
 };

--- a/supabase/migrations/20250201000000_add_recommended_sale_price.sql
+++ b/supabase/migrations/20250201000000_add_recommended_sale_price.sql
@@ -1,0 +1,35 @@
+/*
+  # Ajout du prix de vente conseillé (TTC) aux collections
+  
+  1. Changements
+    - Ajout de `recommended_sale_price` dans `collections`
+      - Nullable : prix de vente conseillé TTC par défaut pour la collection
+      - numeric(10,2) pour permettre les décimales
+    - Ajout de `custom_recommended_sale_price` dans `client_collections`
+      - Nullable : si NULL, utiliser le prix par défaut de la collection (recommended_sale_price)
+      - Si non NULL, utiliser ce prix spécifique pour ce client
+    2. Logique
+    - Lors de l'association d'une collection à un client, on peut :
+      * Laisser custom_recommended_sale_price à NULL → utilise collections.recommended_sale_price
+      * Définir custom_recommended_sale_price → utilise ce prix spécifique
+    3. Notes
+    - Le prix est stocké en numeric(10,2) pour la cohérence avec les autres champs de prix
+    - La migration est idempotente (ADD COLUMN IF NOT EXISTS)
+*/
+
+-- Ajouter le champ recommended_sale_price à collections
+ALTER TABLE collections
+ADD COLUMN IF NOT EXISTS recommended_sale_price numeric(10,2) DEFAULT NULL;
+
+-- Ajouter le champ custom_recommended_sale_price à client_collections
+ALTER TABLE client_collections
+ADD COLUMN IF NOT EXISTS custom_recommended_sale_price numeric(10,2) DEFAULT NULL;
+
+-- Créer un index pour améliorer les performances
+CREATE INDEX IF NOT EXISTS idx_collections_recommended_sale_price ON collections(recommended_sale_price) WHERE recommended_sale_price IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_client_collections_custom_recommended_sale_price ON client_collections(custom_recommended_sale_price) WHERE custom_recommended_sale_price IS NOT NULL;
+
+-- Ajouter des commentaires pour documenter les champs
+COMMENT ON COLUMN collections.recommended_sale_price IS 'Prix de vente conseillé TTC par défaut pour cette collection';
+COMMENT ON COLUMN client_collections.custom_recommended_sale_price IS 'Prix de vente conseillé TTC personnalisé pour cette collection chez ce client. Si NULL, utiliser le prix par défaut de la collection.';
+


### PR DESCRIPTION
- Migration pour ajouter recommended_sale_price aux collections et custom_recommended_sale_price aux client_collections
- Modification des libellÃ©s : 'Prix de la collection' -> 'Prix de cession (HT)'
- Ajout du champ 'Prix de vente conseillÃ© (TTC)' dans les formulaires de collections
- Ajout du choix du prix de vente conseillÃ© lors de l'association d'une collection Ã  un client
- Modification du tableau des stocks : remplacement de 'Prix' par 'Prix de cession (HT)' et ajout de 'Prix de vente conseillÃ© (TTC)'
- Modification du bon de dÃ©pÃ´t : ajout des colonnes 'Prix de cession (HT)' et 'Prix de vente conseillÃ© (TTC)' avec largeur identique de 10% chacune