### PR TITLE
feat: Ajout de la gestion des sous-produits aux collections - CrÃ©ati…

### DIFF
--- a/DRAFT_SYSTEM_README.md
+++ b/DRAFT_SYSTEM_README.md
@@ -250,3 +250,4 @@ En cas de problème:
 
 
 
+

--- a/app/collections/[id]/page.tsx
+++ b/app/collections/[id]/page.tsx
@@ -7,7 +7,9 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { ArrowLeft, Euro, Package, Edit, Trash2 } from 'lucide-react';
+import { ArrowLeft, Euro, Package, Edit, Trash2, Plus, X } from 'lucide-react';
+import { Checkbox } from '@/components/ui/checkbox';
+import { SubProduct } from '@/lib/supabase';
 import { toast } from 'sonner';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from '@/components/ui/alert-dialog';
 
@@ -17,6 +19,7 @@ export default function CollectionDetailPage() {
   const collectionId = params.id as string;
 
   const [collection, setCollection] = useState<Collection | null>(null);
+  const [existingSubProducts, setExistingSubProducts] = useState<SubProduct[]>([]);
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [formData, setFormData] = useState({
@@ -25,6 +28,9 @@ export default function CollectionDetailPage() {
     recommended_sale_price: '',
     barcode: ''
   });
+  const [hasSubProducts, setHasSubProducts] = useState(false);
+  const [subProducts, setSubProducts] = useState<{ id: string | null; name: string }[]>([]);
+  const [deleteSubProductIndex, setDeleteSubProductIndex] = useState<number | null>(null);
 
   useEffect(() => {
     loadCollectionData();
@@ -53,6 +59,24 @@ export default function CollectionDetailPage() {
         recommended_sale_price: collectionData.recommended_sale_price?.toString() || '',
         barcode: collectionData.barcode || ''
       });
+
+      // Load sub-products
+      const { data: subProductsData, error: subProductsError } = await supabase
+        .from('sub_products')
+        .select('*')
+        .eq('collection_id', collectionId)
+        .order('created_at', { ascending: true });
+
+      if (subProductsError) throw subProductsError;
+      
+      if (subProductsData && subProductsData.length > 0) {
+        setExistingSubProducts(subProductsData);
+        setHasSubProducts(true);
+        setSubProducts(subProductsData.map(sp => ({ id: sp.id, name: sp.name })));
+      } else {
+        setHasSubProducts(false);
+        setSubProducts([{ id: null, name: '' }]);
+      }
     } catch (error) {
       console.error('Error loading collection data:', error);
       toast.error('Erreur lors du chargement des données');
@@ -102,6 +126,58 @@ export default function CollectionDetailPage() {
         .eq('id', collectionId);
 
       if (error) throw error;
+
+      // Handle sub-products
+      if (hasSubProducts) {
+        const validSubProducts = subProducts.filter(sp => sp.name.trim() !== '');
+        
+        // Get existing IDs
+        const existingIds = existingSubProducts.map(sp => sp.id);
+        const currentIds = validSubProducts.filter(sp => sp.id !== null).map(sp => sp.id as string);
+        
+        // Delete removed sub-products
+        const toDelete = existingIds.filter(id => !currentIds.includes(id));
+        if (toDelete.length > 0) {
+          const { error: deleteError } = await supabase
+            .from('sub_products')
+            .delete()
+            .in('id', toDelete);
+          if (deleteError) throw deleteError;
+        }
+
+        // Update or insert sub-products
+        for (const sp of validSubProducts) {
+          if (sp.id) {
+            // Update existing
+            const { error: updateError } = await supabase
+              .from('sub_products')
+              .update({
+                name: sp.name.trim(),
+                updated_at: new Date().toISOString()
+              })
+              .eq('id', sp.id);
+            if (updateError) throw updateError;
+          } else {
+            // Insert new
+            const { error: insertError } = await supabase
+              .from('sub_products')
+              .insert({
+                collection_id: collectionId,
+                name: sp.name.trim()
+              });
+            if (insertError) throw insertError;
+          }
+        }
+      } else {
+        // Remove all sub-products if hasSubProducts is false
+        if (existingSubProducts.length > 0) {
+          const { error: deleteError } = await supabase
+            .from('sub_products')
+            .delete()
+            .eq('collection_id', collectionId);
+          if (deleteError) throw deleteError;
+        }
+      }
 
       toast.success('Collection modifiée avec succès');
       await loadCollectionData();
@@ -308,6 +384,70 @@ export default function CollectionDetailPage() {
                   </div>
                 </div>
 
+                <div className="space-y-3 border border-slate-200 rounded-lg p-4 bg-slate-50">
+                  <div className="flex items-center space-x-2">
+                    <Checkbox
+                      id="has-sub-products-edit"
+                      checked={hasSubProducts}
+                      onCheckedChange={(checked) => {
+                        setHasSubProducts(checked === true);
+                        if (checked === false) {
+                          setSubProducts([{ id: null, name: '' }]);
+                        } else if (subProducts.length === 0 || (subProducts.length === 1 && subProducts[0].name === '')) {
+                          setSubProducts([{ id: null, name: '' }]);
+                        }
+                      }}
+                    />
+                    <Label htmlFor="has-sub-products-edit" className="font-normal cursor-pointer">
+                      Cette collection contient des sous-produits
+                    </Label>
+                  </div>
+
+                  {hasSubProducts && (
+                    <div className="space-y-2 pt-2">
+                      <Label className="text-sm">Sous-produits</Label>
+                      {subProducts.map((subProduct, index) => (
+                        <div key={index} className="flex gap-2">
+                          <Input
+                            type="text"
+                            value={subProduct.name}
+                            onChange={(e) => {
+                              const newSubProducts = [...subProducts];
+                              newSubProducts[index] = { ...newSubProducts[index], name: e.target.value };
+                              setSubProducts(newSubProducts);
+                            }}
+                            placeholder={`Nom du sous-produit ${index + 1}`}
+                            className="flex-1"
+                          />
+                          {subProducts.length > 1 && (
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => {
+                                setDeleteSubProductIndex(index);
+                              }}
+                              className="h-9 w-9 p-0"
+                            >
+                              <X className="h-4 w-4" />
+                            </Button>
+                          )}
+                        </div>
+                      ))}
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setSubProducts([...subProducts, { id: null, name: '' }])}
+                        className="w-full"
+                      >
+                        <Plus className="mr-2 h-4 w-4" />
+                        Ajouter un sous-produit
+                      </Button>
+                    </div>
+                  )}
+                </div>
+
                 <Button type="submit" disabled={submitting} className="w-full md:w-auto">
                   {submitting ? 'Modification en cours...' : 'Modifier la collection'}
                 </Button>
@@ -315,6 +455,32 @@ export default function CollectionDetailPage() {
             </CardContent>
           </Card>
         </div>
+
+        {/* Delete Sub-Product Confirmation Dialog */}
+        <AlertDialog open={deleteSubProductIndex !== null} onOpenChange={(open) => !open && setDeleteSubProductIndex(null)}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Supprimer le sous-produit ?</AlertDialogTitle>
+              <AlertDialogDescription>
+                Êtes-vous sûr de vouloir supprimer le sous-produit "{subProducts[deleteSubProductIndex || 0]?.name || 'sans nom'}" ? Cette action ne peut pas être annulée.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Annuler</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={() => {
+                  if (deleteSubProductIndex !== null) {
+                    setSubProducts(subProducts.filter((_, i) => i !== deleteSubProductIndex));
+                    setDeleteSubProductIndex(null);
+                  }
+                }}
+                className="bg-red-600 hover:bg-red-700"
+              >
+                Supprimer
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       </div>
     </div>
   );

--- a/hooks/use-stock-update-draft.ts
+++ b/hooks/use-stock-update-draft.ts
@@ -242,10 +242,15 @@ export function useStockUpdateDraft(clientId: string) {
       form => form.counted_stock !== '' || form.cards_added !== '' || form.collection_info !== ''
     );
 
+    // Check if any sub-product form has data
+    const hasSubProductData = data.perSubProductForm ? Object.values(data.perSubProductForm).some(
+      form => form.counted_stock !== '' || form.cards_added !== ''
+    ) : false;
+
     // Check if any adjustments exist
     const hasAdjustments = data.pendingAdjustments.length > 0;
 
-    return !hasCollectionData && !hasAdjustments;
+    return !hasCollectionData && !hasSubProductData && !hasAdjustments;
   }, []);
 
   // Check if draft has meaningful data that warrants showing recovery dialog
@@ -256,10 +261,15 @@ export function useStockUpdateDraft(clientId: string) {
       form => form.counted_stock !== '' || form.cards_added !== ''
     );
 
+    // Check if any sub-product form has stock data
+    const hasSubProductStockData = data.perSubProductForm ? Object.values(data.perSubProductForm).some(
+      form => form.counted_stock !== '' || form.cards_added !== ''
+    ) : false;
+
     // Adjustments also count as meaningful data
     const hasAdjustments = data.pendingAdjustments.length > 0;
 
-    return hasStockData || hasAdjustments;
+    return hasStockData || hasSubProductStockData || hasAdjustments;
   }, []);
 
   // Auto-save function (saves to local immediately, syncs to server periodically)

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -93,6 +93,24 @@ export type Collection = {
   updated_at: string;
 };
 
+export type SubProduct = {
+  id: string;
+  collection_id: string;
+  name: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type ClientSubProduct = {
+  id: string;
+  client_id: string;
+  sub_product_id: string;
+  initial_stock: number;
+  current_stock: number;
+  created_at: string;
+  updated_at: string;
+};
+
 export type ClientCollection = {
   id: string;
   client_id: string;
@@ -124,6 +142,7 @@ export type UserProfile = {
 
 export type DraftStockUpdateData = {
   perCollectionForm: Record<string, { counted_stock: string; cards_added: string; collection_info: string }>;
+  perSubProductForm?: Record<string, { counted_stock: string; cards_added: string }>;
   pendingAdjustments: { operation_name: string; unit_price: string; quantity: string }[];
 };
 

--- a/supabase/migrations/20250202000000_create_sub_products.sql
+++ b/supabase/migrations/20250202000000_create_sub_products.sql
@@ -1,0 +1,102 @@
+/*
+  # Ajout des sous-produits aux collections
+  
+  1. Tables créées
+    - `sub_products`
+      - `id` (uuid, clé primaire)
+      - `collection_id` (uuid, référence vers collections)
+      - `name` (text, nom du sous-produit)
+      - `created_at` (timestamp, date de création)
+      - `updated_at` (timestamp, date de dernière mise à jour)
+    
+    - `client_sub_products`
+      - `id` (uuid, clé primaire)
+      - `client_id` (uuid, référence vers clients)
+      - `sub_product_id` (uuid, référence vers sub_products)
+      - `initial_stock` (integer, stock initial)
+      - `current_stock` (integer, stock actuel)
+      - `created_at` (timestamp, date de création)
+      - `updated_at` (timestamp, date de dernière mise à jour)
+      - UNIQUE (client_id, sub_product_id)
+  
+  2. Logique
+    - Un sous-produit appartient à une collection
+    - Le stock d'une collection avec sous-produits = somme des stocks de ses sous-produits
+    - Les sous-produits héritent du prix et autres caractéristiques de la collection parent
+  
+  3. Sécurité
+    - RLS activé sur toutes les tables
+    - Politiques d'accès publiques
+*/
+
+-- Table des sous-produits
+CREATE TABLE IF NOT EXISTS sub_products (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  collection_id uuid NOT NULL REFERENCES collections(id) ON DELETE CASCADE,
+  name text NOT NULL,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now(),
+  UNIQUE (collection_id, name)
+);
+
+-- Table de liaison client-sous-produits avec stock
+CREATE TABLE IF NOT EXISTS client_sub_products (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  client_id uuid NOT NULL REFERENCES clients(id) ON DELETE CASCADE,
+  sub_product_id uuid NOT NULL REFERENCES sub_products(id) ON DELETE CASCADE,
+  initial_stock integer NOT NULL DEFAULT 0,
+  current_stock integer NOT NULL DEFAULT 0,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now(),
+  UNIQUE (client_id, sub_product_id)
+);
+
+-- RLS pour sub_products
+ALTER TABLE sub_products ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow public read access to sub_products"
+  ON sub_products FOR SELECT
+  USING (true);
+
+CREATE POLICY "Allow public insert access to sub_products"
+  ON sub_products FOR INSERT
+  WITH CHECK (true);
+
+CREATE POLICY "Allow public update access to sub_products"
+  ON sub_products FOR UPDATE
+  USING (true)
+  WITH CHECK (true);
+
+CREATE POLICY "Allow public delete access to sub_products"
+  ON sub_products FOR DELETE
+  USING (true);
+
+-- RLS pour client_sub_products
+ALTER TABLE client_sub_products ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow public read access to client_sub_products"
+  ON client_sub_products FOR SELECT
+  USING (true);
+
+CREATE POLICY "Allow public insert access to client_sub_products"
+  ON client_sub_products FOR INSERT
+  WITH CHECK (true);
+
+CREATE POLICY "Allow public update access to client_sub_products"
+  ON client_sub_products FOR UPDATE
+  USING (true)
+  WITH CHECK (true);
+
+CREATE POLICY "Allow public delete access to client_sub_products"
+  ON client_sub_products FOR DELETE
+  USING (true);
+
+-- Index pour améliorer les performances
+CREATE INDEX IF NOT EXISTS idx_sub_products_collection_id ON sub_products(collection_id);
+CREATE INDEX IF NOT EXISTS idx_client_sub_products_client_id ON client_sub_products(client_id);
+CREATE INDEX IF NOT EXISTS idx_client_sub_products_sub_product_id ON client_sub_products(sub_product_id);
+
+-- Commentaires
+COMMENT ON TABLE sub_products IS 'Sous-produits appartenant à une collection. Ils héritent du prix et autres caractéristiques de la collection parent.';
+COMMENT ON TABLE client_sub_products IS 'Gestion des stocks des sous-produits par client. Le stock d''une collection = somme des stocks de ses sous-produits.';
+


### PR DESCRIPTION
…on des tables sub_products et client_sub_products - Ajout de la possibilitÃ© de crÃ©er et modifier des sous-produits dans les collections - Gestion des stocks par sous-produit (stock parent = somme des sous-produits) - Interface avec dÃ©calage visuel pour les sous-produits - Dialog pour saisir les stocks initiaux des sous-produits lors de l'association - Confirmation avant suppression des sous-produits - IntÃ©gration du systÃ¨me de brouillon pour les sous-produits - DÃ©sactivation du champ stock initial pour les collections avec sous-produits