### PR TITLE
Add unit_price_ht and total_amount_ht to stock updates

### DIFF
--- a/app/clients/[id]/page.tsx
+++ b/app/clients/[id]/page.tsx
@@ -1344,6 +1344,11 @@ export default function ClientDetailPage() {
             // (totalCardsSold > 0). Si aucune carte n'est vendue, pas de ligne dans stock_updates.
             if (totalCardsSold > 0) {
               const collectionInfo = perCollectionForm[cc.id]?.collection_info || '';
+              // Calculer le prix effectif de la collection
+              const effectivePrice = cc.custom_price ?? cc.collection?.price ?? 0;
+              // Calculer unit_price_ht et total_amount_ht uniquement si une facture est générée
+              const unitPriceHt = invoiceData ? effectivePrice : null;
+              const totalAmountHt = invoiceData && unitPriceHt ? totalCardsSold * unitPriceHt : null;
               
               updatesToInsert.push({
                 client_id: clientId,
@@ -1354,7 +1359,9 @@ export default function ClientDetailPage() {
                 cards_sold: totalCardsSold,
                 cards_added: totalCardsAdded,
                 new_stock: totalNewStock,
-                collection_info: collectionInfo
+                collection_info: collectionInfo,
+                unit_price_ht: unitPriceHt,
+                total_amount_ht: totalAmountHt
               });
             }
 
@@ -1374,6 +1381,11 @@ export default function ClientDetailPage() {
             const newStock = newDeposit;
             const cardsAdded = Math.max(0, newStock - countedStock);
             const collectionInfo = form.collection_info || '';
+            // Calculer le prix effectif de la collection
+            const effectivePrice = cc.custom_price ?? cc.collection?.price ?? 0;
+            // Calculer unit_price_ht et total_amount_ht uniquement si une facture est générée et des cartes sont vendues
+            const unitPriceHt = invoiceData && cardsSold > 0 ? effectivePrice : null;
+            const totalAmountHt = invoiceData && cardsSold > 0 && unitPriceHt ? cardsSold * unitPriceHt : null;
 
             updatesToInsert.push({
               client_id: clientId,
@@ -1384,7 +1396,9 @@ export default function ClientDetailPage() {
               cards_sold: cardsSold,
               cards_added: cardsAdded,
               new_stock: newStock,
-              collection_info: collectionInfo
+              collection_info: collectionInfo,
+              unit_price_ht: unitPriceHt,
+              total_amount_ht: totalAmountHt
             });
             ccUpdates.push({ id: cc.id, new_stock: newStock });
           }

--- a/lib/pdf-generators.ts
+++ b/lib/pdf-generators.ts
@@ -274,7 +274,7 @@ export async function generateAndSaveInvoicePDF(params: GenerateInvoicePDFParams
         update.counted_stock.toString(),
         update.cards_sold.toString(),
         effectivePrice.toFixed(2) + ' €',
-        totalHTAfterDiscount.toFixed(2) + ' €'
+        totalHTBeforeDiscount.toFixed(2) + ' €' // Afficher le prix HT avant remise
       ];
     });
 
@@ -284,7 +284,8 @@ export async function generateAndSaveInvoicePDF(params: GenerateInvoicePDFParams
       const amtBeforeDiscount = isNaN(amt) ? 0 : amt;
       // Appliquer la remise proportionnellement aux ajustements (conforme fiscalement)
       const amtAfterDiscount = amtBeforeDiscount * discountRatio;
-      const amtStr = amtAfterDiscount.toFixed(2) + ' €';
+      // Afficher le prix HT avant remise dans la colonne "Prix TOTAL H.T."
+      const amtStr = amtBeforeDiscount.toFixed(2) + ' €';
       const quantity = adj.quantity || '';
       const unitPrice = adj.unit_price ? (Number(adj.unit_price).toFixed(2) + ' €') : '';
       return [

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -66,6 +66,8 @@ export type StockUpdate = {
   cards_added: number;
   new_stock: number;
   collection_info?: string | null;
+  unit_price_ht?: number | null; // Prix unitaire HT auquel est vendu la collection
+  total_amount_ht?: number | null; // Montant total HT : cards_sold x unit_price_ht
   created_at: string;
 };
 

--- a/supabase/migrations/20250212000000_add_unit_price_and_total_amount_to_stock_updates.sql
+++ b/supabase/migrations/20250212000000_add_unit_price_and_total_amount_to_stock_updates.sql
@@ -1,0 +1,18 @@
+/*
+  # Ajout des colonnes unit_price_ht et total_amount_ht à stock_updates
+
+  1. Ajout de la colonne unit_price_ht : Prix auquel est vendu la collection (HT)
+  2. Ajout de la colonne total_amount_ht : Nombre de cartes vendues x unit_price_ht
+  
+  Ces colonnes sont renseignées uniquement lors de la génération d'une facture (quand des cartes sont vendues).
+  Elles restent null pour les ajustements de stock (modifications de stock sans vente).
+*/
+
+-- Ajouter les colonnes unit_price_ht et total_amount_ht
+ALTER TABLE stock_updates
+  ADD COLUMN IF NOT EXISTS unit_price_ht numeric(10, 2) NULL,
+  ADD COLUMN IF NOT EXISTS total_amount_ht numeric(10, 2) NULL;
+
+-- Commentaires
+COMMENT ON COLUMN stock_updates.unit_price_ht IS 'Prix unitaire HT auquel est vendu la collection (renseigné uniquement lors de la génération d''une facture)';
+COMMENT ON COLUMN stock_updates.total_amount_ht IS 'Montant total HT : nombre de cartes vendues x unit_price_ht (renseigné uniquement lors de la génération d''une facture)';


### PR DESCRIPTION
- Introduced unit_price_ht and total_amount_ht fields in stock_updates for better invoice management.
- Updated ClientDetailPage to calculate and store these values during stock updates when invoices are generated.
- Modified PDF generation logic to display total amounts before discounts.
- Added database migration to include new fields in the stock_updates table.