### PR TITLE
Implement soft delete functionality across multiple tables

### DIFF
--- a/app/clients/page.tsx
+++ b/app/clients/page.tsx
@@ -159,6 +159,7 @@ export default function ClientsPage() {
       const { data, error } = await supabase
         .from('clients')
         .select('*')
+        .is('deleted_at', null)
         .order('created_at', { ascending: false });
 
       if (error) throw error;

--- a/supabase/migrations/20250213000000_add_soft_delete_to_all_tables.sql
+++ b/supabase/migrations/20250213000000_add_soft_delete_to_all_tables.sql
@@ -1,0 +1,140 @@
+/*
+  # Ajout du soft delete (suppression logique) à toutes les tables
+  
+  Cette migration ajoute une colonne `deleted_at` (timestamp) à toutes les tables
+  qui peuvent être supprimées dans l'application, permettant de conserver toutes
+  les données tout en les masquant de l'affichage.
+  
+  Tables concernées :
+  - clients
+  - client_collections
+  - client_sub_products
+  - establishment_types
+  - payment_methods
+  - collection_categories
+  - collection_subcategories
+  - collections
+  - sub_products
+  - draft_stock_updates
+  
+  Les vues SQL créées permettent de faciliter les requêtes en filtrant automatiquement
+  les enregistrements supprimés.
+*/
+
+-- ============================================
+-- 1. Ajout de la colonne deleted_at
+-- ============================================
+
+-- Clients
+ALTER TABLE clients
+  ADD COLUMN IF NOT EXISTS deleted_at timestamptz NULL;
+
+-- Client collections
+ALTER TABLE client_collections
+  ADD COLUMN IF NOT EXISTS deleted_at timestamptz NULL;
+
+-- Client sub products
+ALTER TABLE client_sub_products
+  ADD COLUMN IF NOT EXISTS deleted_at timestamptz NULL;
+
+-- Establishment types
+ALTER TABLE establishment_types
+  ADD COLUMN IF NOT EXISTS deleted_at timestamptz NULL;
+
+-- Payment methods
+ALTER TABLE payment_methods
+  ADD COLUMN IF NOT EXISTS deleted_at timestamptz NULL;
+
+-- Collection categories
+ALTER TABLE collection_categories
+  ADD COLUMN IF NOT EXISTS deleted_at timestamptz NULL;
+
+-- Collection subcategories
+ALTER TABLE collection_subcategories
+  ADD COLUMN IF NOT EXISTS deleted_at timestamptz NULL;
+
+-- Collections
+ALTER TABLE collections
+  ADD COLUMN IF NOT EXISTS deleted_at timestamptz NULL;
+
+-- Sub products
+ALTER TABLE sub_products
+  ADD COLUMN IF NOT EXISTS deleted_at timestamptz NULL;
+
+-- Draft stock updates
+ALTER TABLE draft_stock_updates
+  ADD COLUMN IF NOT EXISTS deleted_at timestamptz NULL;
+
+-- ============================================
+-- 2. Création d'index pour les performances
+-- ============================================
+
+CREATE INDEX IF NOT EXISTS idx_clients_deleted_at ON clients(deleted_at) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_client_collections_deleted_at ON client_collections(deleted_at) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_client_sub_products_deleted_at ON client_sub_products(deleted_at) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_establishment_types_deleted_at ON establishment_types(deleted_at) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_payment_methods_deleted_at ON payment_methods(deleted_at) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_collection_categories_deleted_at ON collection_categories(deleted_at) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_collection_subcategories_deleted_at ON collection_subcategories(deleted_at) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_collections_deleted_at ON collections(deleted_at) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_sub_products_deleted_at ON sub_products(deleted_at) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_draft_stock_updates_deleted_at ON draft_stock_updates(deleted_at) WHERE deleted_at IS NULL;
+
+-- ============================================
+-- 3. Création de vues SQL pour faciliter les requêtes
+-- ============================================
+
+-- Vue pour les clients actifs
+CREATE OR REPLACE VIEW clients_active AS
+SELECT * FROM clients WHERE deleted_at IS NULL;
+
+-- Vue pour les client_collections actives
+CREATE OR REPLACE VIEW client_collections_active AS
+SELECT * FROM client_collections WHERE deleted_at IS NULL;
+
+-- Vue pour les client_sub_products actifs
+CREATE OR REPLACE VIEW client_sub_products_active AS
+SELECT * FROM client_sub_products WHERE deleted_at IS NULL;
+
+-- Vue pour les establishment_types actifs
+CREATE OR REPLACE VIEW establishment_types_active AS
+SELECT * FROM establishment_types WHERE deleted_at IS NULL;
+
+-- Vue pour les payment_methods actifs
+CREATE OR REPLACE VIEW payment_methods_active AS
+SELECT * FROM payment_methods WHERE deleted_at IS NULL;
+
+-- Vue pour les collection_categories actives
+CREATE OR REPLACE VIEW collection_categories_active AS
+SELECT * FROM collection_categories WHERE deleted_at IS NULL;
+
+-- Vue pour les collection_subcategories actives
+CREATE OR REPLACE VIEW collection_subcategories_active AS
+SELECT * FROM collection_subcategories WHERE deleted_at IS NULL;
+
+-- Vue pour les collections actives
+CREATE OR REPLACE VIEW collections_active AS
+SELECT * FROM collections WHERE deleted_at IS NULL;
+
+-- Vue pour les sub_products actifs
+CREATE OR REPLACE VIEW sub_products_active AS
+SELECT * FROM sub_products WHERE deleted_at IS NULL;
+
+-- Vue pour les draft_stock_updates actifs
+CREATE OR REPLACE VIEW draft_stock_updates_active AS
+SELECT * FROM draft_stock_updates WHERE deleted_at IS NULL;
+
+-- ============================================
+-- 4. Commentaires
+-- ============================================
+
+COMMENT ON COLUMN clients.deleted_at IS 'Date de suppression logique (NULL si non supprimé)';
+COMMENT ON COLUMN client_collections.deleted_at IS 'Date de suppression logique (NULL si non supprimé)';
+COMMENT ON COLUMN client_sub_products.deleted_at IS 'Date de suppression logique (NULL si non supprimé)';
+COMMENT ON COLUMN establishment_types.deleted_at IS 'Date de suppression logique (NULL si non supprimé)';
+COMMENT ON COLUMN payment_methods.deleted_at IS 'Date de suppression logique (NULL si non supprimé)';
+COMMENT ON COLUMN collection_categories.deleted_at IS 'Date de suppression logique (NULL si non supprimé)';
+COMMENT ON COLUMN collection_subcategories.deleted_at IS 'Date de suppression logique (NULL si non supprimé)';
+COMMENT ON COLUMN collections.deleted_at IS 'Date de suppression logique (NULL si non supprimé)';
+COMMENT ON COLUMN sub_products.deleted_at IS 'Date de suppression logique (NULL si non supprimé)';
+COMMENT ON COLUMN draft_stock_updates.deleted_at IS 'Date de suppression logique (NULL si non supprimé)';

--- a/supabase/migrations/20250213000001_make_unique_constraints_partial_for_soft_delete.sql
+++ b/supabase/migrations/20250213000001_make_unique_constraints_partial_for_soft_delete.sql
@@ -1,0 +1,128 @@
+/*
+  # Modification des contraintes UNIQUE pour supporter le soft delete
+  
+  Cette migration modifie les contraintes UNIQUE pour qu'elles soient partielles,
+  c'est-à-dire qu'elles ne s'appliquent qu'aux enregistrements non supprimés (deleted_at IS NULL).
+  
+  Cela permet de recréer un élément avec le même nom qu'un élément supprimé.
+  
+  Tables concernées :
+  - establishment_types (name)
+  - payment_methods (name)
+  - collection_categories (name)
+  - collection_subcategories (category_id, name)
+  - sub_products (collection_id, name)
+  - client_collections (client_id, collection_id)
+  - client_sub_products (client_id, sub_product_id)
+*/
+
+-- ============================================
+-- 1. establishment_types
+-- ============================================
+
+-- Supprimer la contrainte UNIQUE existante sur name
+ALTER TABLE establishment_types
+  DROP CONSTRAINT IF EXISTS establishment_types_name_key;
+
+-- Créer une contrainte UNIQUE partielle (uniquement sur les enregistrements non supprimés)
+CREATE UNIQUE INDEX IF NOT EXISTS establishment_types_name_unique_not_deleted
+  ON establishment_types(name)
+  WHERE deleted_at IS NULL;
+
+-- ============================================
+-- 2. payment_methods
+-- ============================================
+
+-- Supprimer la contrainte UNIQUE existante sur name
+ALTER TABLE payment_methods
+  DROP CONSTRAINT IF EXISTS payment_methods_name_key;
+
+-- Créer une contrainte UNIQUE partielle (uniquement sur les enregistrements non supprimés)
+CREATE UNIQUE INDEX IF NOT EXISTS payment_methods_name_unique_not_deleted
+  ON payment_methods(name)
+  WHERE deleted_at IS NULL;
+
+-- ============================================
+-- 3. collection_categories
+-- ============================================
+
+-- Supprimer la contrainte UNIQUE existante sur name
+ALTER TABLE collection_categories
+  DROP CONSTRAINT IF EXISTS collection_categories_name_key;
+
+-- Créer une contrainte UNIQUE partielle (uniquement sur les enregistrements non supprimés)
+CREATE UNIQUE INDEX IF NOT EXISTS collection_categories_name_unique_not_deleted
+  ON collection_categories(name)
+  WHERE deleted_at IS NULL;
+
+-- ============================================
+-- 4. collection_subcategories
+-- ============================================
+
+-- Supprimer la contrainte UNIQUE existante sur (category_id, name)
+ALTER TABLE collection_subcategories
+  DROP CONSTRAINT IF EXISTS collection_subcategories_category_id_name_key;
+
+-- Créer une contrainte UNIQUE partielle (uniquement sur les enregistrements non supprimés)
+CREATE UNIQUE INDEX IF NOT EXISTS collection_subcategories_category_id_name_unique_not_deleted
+  ON collection_subcategories(category_id, name)
+  WHERE deleted_at IS NULL;
+
+-- ============================================
+-- 5. Commentaires
+-- ============================================
+
+-- ============================================
+-- 5. sub_products
+-- ============================================
+
+-- Supprimer la contrainte UNIQUE existante sur (collection_id, name)
+ALTER TABLE sub_products
+  DROP CONSTRAINT IF EXISTS sub_products_collection_id_name_key;
+
+-- Créer une contrainte UNIQUE partielle (uniquement sur les enregistrements non supprimés)
+CREATE UNIQUE INDEX IF NOT EXISTS sub_products_collection_id_name_unique_not_deleted
+  ON sub_products(collection_id, name)
+  WHERE deleted_at IS NULL;
+
+-- ============================================
+-- 6. client_collections
+-- ============================================
+
+-- Supprimer la contrainte UNIQUE existante sur (client_id, collection_id)
+ALTER TABLE client_collections
+  DROP CONSTRAINT IF EXISTS client_collections_client_id_collection_id_key;
+
+-- Créer une contrainte UNIQUE partielle (uniquement sur les enregistrements non supprimés)
+CREATE UNIQUE INDEX IF NOT EXISTS client_collections_client_id_collection_id_unique_not_deleted
+  ON client_collections(client_id, collection_id)
+  WHERE deleted_at IS NULL;
+
+-- ============================================
+-- 7. client_sub_products
+-- ============================================
+
+-- Supprimer la contrainte UNIQUE existante sur (client_id, sub_product_id)
+ALTER TABLE client_sub_products
+  DROP CONSTRAINT IF EXISTS client_sub_products_client_id_sub_product_id_key;
+
+-- Créer une contrainte UNIQUE partielle (uniquement sur les enregistrements non supprimés)
+CREATE UNIQUE INDEX IF NOT EXISTS client_sub_products_client_id_sub_product_id_unique_not_deleted
+  ON client_sub_products(client_id, sub_product_id)
+  WHERE deleted_at IS NULL;
+
+-- ============================================
+-- 8. Commentaires
+-- ============================================
+
+COMMENT ON INDEX establishment_types_name_unique_not_deleted IS 'Contrainte UNIQUE partielle sur name pour les enregistrements non supprimés';
+COMMENT ON INDEX payment_methods_name_unique_not_deleted IS 'Contrainte UNIQUE partielle sur name pour les enregistrements non supprimés';
+COMMENT ON INDEX collection_categories_name_unique_not_deleted IS 'Contrainte UNIQUE partielle sur name pour les enregistrements non supprimés';
+COMMENT ON INDEX collection_subcategories_category_id_name_unique_not_deleted IS 'Contrainte UNIQUE partielle sur (category_id, name) pour les enregistrements non supprimés';
+COMMENT ON INDEX sub_products_collection_id_name_unique_not_deleted IS 'Contrainte UNIQUE partielle sur (collection_id, name) pour les enregistrements non supprimés';
+COMMENT ON INDEX client_collections_client_id_collection_id_unique_not_deleted IS 'Contrainte UNIQUE partielle sur (client_id, collection_id) pour les enregistrements non supprimés';
+COMMENT ON INDEX client_sub_products_client_id_sub_product_id_unique_not_deleted IS 'Contrainte UNIQUE partielle sur (client_id, sub_product_id) pour les enregistrements non supprimés';
+
+
+
+


### PR DESCRIPTION
- Added a `deleted_at` column to support soft deletes in the database schema.
- Updated relevant queries to filter out soft-deleted records by adding `.is('deleted_at', null)` where necessary.
- Modified delete operations to use soft delete by updating the `deleted_at` timestamp instead of actual deletion.
- Introduced helper functions for soft delete and undelete operations.
- Ensured unique constraints are now partial, allowing reuse of names for soft-deleted records.
- Created database migrations to apply these changes across all affected tables.