### PR TITLE
Add "Nom du responsable" field to client management

### DIFF
--- a/app/clients/[id]/info/page.tsx
+++ b/app/clients/[id]/info/page.tsx
@@ -204,6 +204,7 @@ export default function ClientInfoPage() {
     longitude: null as number | null,
     phone: '',
     phone_1_info: '',
+    responsable_name: '',
     phone_2: '',
     phone_2_info: '',
     phone_3: '',
@@ -390,6 +391,7 @@ export default function ClientInfoPage() {
         longitude: data.longitude || null,
         phone: data.phone || '',
         phone_1_info: data.phone_1_info || '',
+        responsable_name: data.responsable_name || data.phone_1_info || '',
         phone_2: data.phone_2 || '',
         phone_2_info: data.phone_2_info || '',
         phone_3: data.phone_3 || '',
@@ -910,6 +912,7 @@ export default function ClientInfoPage() {
       formData.longitude !== (client.longitude ?? null) ||
       normalize(formData.phone) !== normalize(client.phone) ||
       normalize(formData.phone_1_info) !== normalize(client.phone_1_info) ||
+      normalize(formData.responsable_name) !== normalize(client.responsable_name) ||
       normalize(formData.phone_2) !== normalize(client.phone_2) ||
       normalize(formData.phone_2_info) !== normalize(client.phone_2_info) ||
       normalize(formData.phone_3) !== normalize(client.phone_3) ||
@@ -1003,6 +1006,7 @@ export default function ClientInfoPage() {
       longitude: client.longitude || null,
       phone: client.phone || '',
       phone_1_info: client.phone_1_info || '',
+      responsable_name: client.responsable_name || client.phone_1_info || '',
       phone_2: client.phone_2 || '',
       phone_2_info: client.phone_2_info || '',
       phone_3: client.phone_3 || '',
@@ -1188,6 +1192,7 @@ export default function ClientInfoPage() {
           longitude: formData.longitude,
           phone: formData.phone || null,
           phone_1_info: formData.phone_1_info || null,
+          responsable_name: formData.responsable_name?.trim() || null,
           phone_2: formData.phone_2 || null,
           phone_2_info: formData.phone_2_info || null,
           phone_3: formData.phone_3 || null,
@@ -1553,6 +1558,20 @@ export default function ClientInfoPage() {
                   
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                     <div>
+                      <Label className="text-slate-500 text-sm">Nom du responsable</Label>
+                      <p className="text-lg font-medium mt-1">
+                        {client.responsable_name || <span className="text-slate-400">Non renseigné</span>}
+                      </p>
+                    </div>
+
+                    <div>
+                      <Label className="text-slate-500 text-sm">Email</Label>
+                      <p className="text-lg font-medium mt-1">
+                        {client.email || <span className="text-slate-400">Non renseigné</span>}
+                      </p>
+                    </div>
+
+                    <div>
                       <Label className="text-slate-500 text-sm">Téléphone 1</Label>
                       <p className="text-lg font-medium mt-1">
                         {formatPhoneNumber(client.phone) || <span className="text-slate-400">Non renseigné</span>}
@@ -1591,13 +1610,6 @@ export default function ClientInfoPage() {
                       <Label className="text-slate-500 text-sm">Info Téléphone 3</Label>
                       <p className="text-lg font-medium mt-1">
                         {client.phone_3_info || <span className="text-slate-400">Non renseigné</span>}
-                      </p>
-                    </div>
-
-                    <div>
-                      <Label className="text-slate-500 text-sm">Email</Label>
-                      <p className="text-lg font-medium mt-1">
-                        {client.email || <span className="text-slate-400">Non renseigné</span>}
                       </p>
                     </div>
                   </div>
@@ -2211,6 +2223,36 @@ export default function ClientInfoPage() {
                 
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <div>
+                    <Label htmlFor="responsable_name">Nom du responsable
+
+                    <span className="text-xs text-slate-500 ml-2">(pour facture & bon de dépôt)</span>
+
+
+
+                    </Label>
+                    <Input
+                      id="responsable_name"
+                      value={formData.responsable_name}
+                      onChange={(e) => setFormData({ ...formData, responsable_name: e.target.value })}
+                      placeholder="Ex: M. Dupont"
+                      className="mt-1.5"
+                    />
+
+                  </div>
+
+                  <div>
+                    <Label htmlFor="email">Email</Label>
+                    <Input
+                      id="email"
+                      type="email"
+                      value={formData.email}
+                      onChange={(e) => setFormData({ ...formData, email: e.target.value })}
+                      placeholder="contact@exemple.fr"
+                      className="mt-1.5"
+                    />
+                  </div>
+
+                  <div>
                     <Label htmlFor="phone">Téléphone 1</Label>
                     <Input
                       id="phone"
@@ -2275,18 +2317,6 @@ export default function ClientInfoPage() {
                       value={formData.phone_3_info}
                       onChange={(e) => setFormData({ ...formData, phone_3_info: e.target.value })}
                       placeholder="Ex: Jean Martin"
-                      className="mt-1.5"
-                    />
-                  </div>
-
-                  <div>
-                    <Label htmlFor="email">Email</Label>
-                    <Input
-                      id="email"
-                      type="email"
-                      value={formData.email}
-                      onChange={(e) => setFormData({ ...formData, email: e.target.value })}
-                      placeholder="contact@exemple.fr"
                       className="mt-1.5"
                     />
                   </div>

--- a/app/clients/[id]/page.tsx
+++ b/app/clients/[id]/page.tsx
@@ -3111,9 +3111,9 @@ export default function ClientDetailPage() {
                         <div>
                           <span className="font-medium text-slate-700 text-base">Tél : </span>
                           <span className="text-[#0B1F33] font-bold text-base">{formatPhoneNumber(client.phone)}</span>
-                          {client.phone_1_info && (
-                            <span className="text-slate-500 ml-1 text-sm">({client.phone_1_info})</span>
-                          )}
+                    {(client.responsable_name || client.phone_1_info) && (
+                      <span className="text-slate-500 ml-1 text-sm">({client.responsable_name || client.phone_1_info})</span>
+                    )}
                         </div>
                       </div>
                     )}

--- a/app/clients/new/page.tsx
+++ b/app/clients/new/page.tsx
@@ -140,6 +140,7 @@ export default function NewClientPage() {
     longitude: null as number | null,
     phone: '',
     phone_1_info: '',
+    responsable_name: '',
     phone_2: '',
     phone_2_info: '',
     phone_3: '',
@@ -692,6 +693,7 @@ export default function NewClientPage() {
           longitude: formData.longitude,
           phone: formData.phone?.trim() || null,
           phone_1_info: formData.phone_1_info?.trim() || null,
+          responsable_name: formData.responsable_name?.trim() || null,
           phone_2: formData.phone_2?.trim() || null,
           phone_2_info: formData.phone_2_info?.trim() || null,
           phone_3: formData.phone_3?.trim() || null,
@@ -1028,6 +1030,32 @@ export default function NewClientPage() {
                 
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <div>
+                    <Label htmlFor="responsable_name">
+                      Nom du responsable
+                      <span className="text-xs text-slate-500 ml-2">(pour facture & bon de dépôt)</span>
+                    </Label>
+                    <Input
+                      id="responsable_name"
+                      value={formData.responsable_name}
+                      onChange={(e) => setFormData({ ...formData, responsable_name: e.target.value })}
+                      placeholder="Ex: M. Dupont"
+                      className="mt-1.5"
+                    />
+                  </div>
+
+                  <div>
+                    <Label htmlFor="email">Email</Label>
+                    <Input
+                      id="email"
+                      type="email"
+                      value={formData.email}
+                      onChange={(e) => setFormData({ ...formData, email: e.target.value })}
+                      placeholder="contact@exemple.fr"
+                      className="mt-1.5"
+                    />
+                  </div>
+
+                  <div>
                     <Label htmlFor="phone">Téléphone 1</Label>
                     <Input
                       id="phone"
@@ -1092,18 +1120,6 @@ export default function NewClientPage() {
                       value={formData.phone_3_info}
                       onChange={(e) => setFormData({ ...formData, phone_3_info: e.target.value })}
                       placeholder="Ex: Jean Martin"
-                      className="mt-1.5"
-                    />
-                  </div>
-
-                  <div>
-                    <Label htmlFor="email">Email</Label>
-                    <Input
-                      id="email"
-                      type="email"
-                      value={formData.email}
-                      onChange={(e) => setFormData({ ...formData, email: e.target.value })}
-                      placeholder="contact@exemple.fr"
                       className="mt-1.5"
                     />
                   </div>

--- a/lib/pdf-generators-direct-invoice.ts
+++ b/lib/pdf-generators-direct-invoice.ts
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * PDF Generator for Direct Invoices
  * 
  * This file contains a function to generate and save PDFs for direct invoices
@@ -317,7 +317,13 @@ export async function generateAndSaveDirectInvoicePDF(params: GenerateDirectInvo
     doc.setFont('helvetica', 'normal');
     doc.setFontSize(9);
     doc.text(`Date: ${new Date(invoice.invoice_date).toLocaleDateString('fr-FR')}`, globalLeftMargin, yPosition);
-    yPosition += 10;
+    const responsableName = client.responsable_name?.trim();
+    if (responsableName) {
+      doc.text(`Nom du responsable : ${responsableName}`, globalLeftMargin, yPosition + 5);
+      yPosition += 12;
+    } else {
+      yPosition += 10;
+    }
 
     // Titre "Facture N°[numero_facture]" en gras
     doc.setFont('helvetica', 'bold');

--- a/lib/pdf-generators.ts
+++ b/lib/pdf-generators.ts
@@ -358,7 +358,13 @@ export async function generateAndSaveInvoicePDF(params: GenerateInvoicePDFParams
     doc.setFont('helvetica', 'normal');
     doc.setFontSize(9);
     doc.text(`Date: ${new Date(invoice.invoice_date).toLocaleDateString('fr-FR')}`, globalLeftMargin, yPosition);
-    yPosition += 10;
+    const responsableName = client.responsable_name?.trim();
+    if (responsableName) {
+      doc.text(`Nom du responsable : ${responsableName}`, globalLeftMargin, yPosition + 5);
+      yPosition += 12;
+    } else {
+      yPosition += 10;
+    }
 
     // Titre "Facture N°[numero_facture]" en gras
     doc.setFont('helvetica', 'bold');
@@ -889,7 +895,13 @@ export async function generateAndSaveStockReportPDF(params: GenerateStockReportP
     
     const invoiceDateText = `Date de facture : ${new Date(invoice.invoice_date).toLocaleDateString('fr-FR')}`;
     doc.text(invoiceDateText, 15, yPosition);
-    yPosition += 10;
+    const responsableName = client.responsable_name?.trim();
+    if (responsableName) {
+      doc.text(`Nom du responsable : ${responsableName}`, 15, yPosition + 5);
+      yPosition += 12;
+    } else {
+      yPosition += 10;
+    }
 
     // Titre "Relevé de stock"
     doc.setFont('helvetica', 'bold');
@@ -1561,8 +1573,14 @@ export async function generateAndSaveDepositSlipPDF(params: GenerateDepositSlipP
     // Date
     doc.setFont('helvetica', 'normal');
     doc.setFontSize(9);
-  doc.text(`Date: ${new Date().toLocaleDateString('fr-FR')}`, 15, yPosition);
-    yPosition += 10;
+    doc.text(`Date: ${new Date().toLocaleDateString('fr-FR')}`, 15, yPosition);
+    const responsableName = client.responsable_name?.trim();
+    if (responsableName) {
+      doc.text(`Nom du responsable : ${responsableName}`, 15, yPosition + 5);
+      yPosition += 12;
+    } else {
+      yPosition += 10;
+    }
 
     // Titre "Bon de dépôt"
     doc.setFont('helvetica', 'bold');
@@ -2053,7 +2071,13 @@ export async function generateAndSaveCreditNotePDF(params: GenerateCreditNotePDF
     doc.setFont('helvetica', 'normal');
     doc.setFontSize(9);
     doc.text(`Date: ${new Date(creditNote.credit_note_date).toLocaleDateString('fr-FR')}`, globalLeftMargin, yPosition);
-    yPosition += 10;
+    const responsableName = client.responsable_name?.trim();
+    if (responsableName) {
+      doc.text(`Nom du responsable : ${responsableName}`, globalLeftMargin, yPosition + 5);
+      yPosition += 12;
+    } else {
+      yPosition += 10;
+    }
 
     // Titre "Avoir N° [numero_avoir]"
     doc.setFont('helvetica', 'bold');
@@ -2240,7 +2264,7 @@ export async function generateClientInfoPDF(
      * HEADER
      * -------------------------------------------------- */
     // Premier contact en haut à gauche (nom + téléphone)
-    const contactName = client.phone_1_info?.trim() || null;
+    const contactName = client.responsable_name?.trim() || client.phone_1_info?.trim() || null;
     const contactPhone = client.phone?.trim()
       ? formatPhoneNumber(client.phone)
       : null;
@@ -2515,6 +2539,16 @@ export async function generateClientInfoPDF(
         ].filter(Boolean).join(' '), 
         fullWidth: true 
       },
+      {
+        label: 'Nom du responsable',
+        value: client.responsable_name || '',
+        column: 'left',
+      },
+      {
+        label: 'Email',
+        value: client.email || '',
+        column: 'right',
+      },
       { 
         label: 'Téléphone 2', 
         value: [
@@ -2529,7 +2563,6 @@ export async function generateClientInfoPDF(
           client.phone_3_info
         ].filter(Boolean).join(' - ') || ''
       },
-      { label: 'Email', value: client.email || '' },
     ]);
 
     const complementaryFields: any[] = [];

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -87,6 +87,7 @@ export type Client = {
   longitude: number | null;
   phone: string | null;
   phone_1_info: string | null;
+  responsable_name: string | null;
   phone_2: string | null;
   phone_2_info: string | null;
   phone_3: string | null;

--- a/supabase/migrations/20260320000000_add_responsable_name_to_clients.sql
+++ b/supabase/migrations/20260320000000_add_responsable_name_to_clients.sql
@@ -1,0 +1,14 @@
+-- Add "Nom du responsable" field to clients table
+-- This value is used in generated PDFs (invoice + deposit slip).
+
+alter table public.clients
+add column if not exists responsable_name text;
+
+-- Backfill existing data: keep current behavior for older clients
+-- by copying "phone_1_info" into the new field when it's empty.
+update public.clients
+set responsable_name = phone_1_info
+where (responsable_name is null or trim(responsable_name) = '')
+  and phone_1_info is not null
+  and trim(phone_1_info) <> '';
+


### PR DESCRIPTION
- Introduced a new field for "Nom du responsable" in client forms and details, enhancing the client information structure.
- Updated PDF generation logic to include the responsible person's name in invoices and other documents.
- Ensured backward compatibility by populating the new field with existing data from "phone_1_info" where applicable.
- Improved user interface by adding input fields for the responsible person's name and email in client creation and editing forms.