### PR TITLE
Refactor client name handling in PDF generation

### DIFF
--- a/components/deposit-slip-dialog.tsx
+++ b/components/deposit-slip-dialog.tsx
@@ -382,11 +382,18 @@ export function DepositSlipDialog({
       doc.setTextColor(0, 0, 0);
       clientYPosition += 4;
       
-      const clientCompanyName = client.company_name || client.name;
-      if (clientCompanyName) {
+      const clientLegalName = client.company_name || client.name;
+      const clientCommercialName = client.name;
+      if (clientLegalName) {
         doc.setFontSize(11);
         doc.setFont('helvetica', 'bold');
-        doc.text(clientCompanyName, rightBoxX + 2, clientYPosition);
+        doc.text(clientLegalName, rightBoxX + 2, clientYPosition);
+        clientYPosition += 5;
+      }
+      if (clientCommercialName && clientCommercialName !== clientLegalName) {
+        doc.setFontSize(11);
+        doc.setFont('helvetica', 'bold');
+        doc.text(clientCommercialName, rightBoxX + 2, clientYPosition);
         clientYPosition += 5;
       }
       

--- a/lib/pdf-generators.ts
+++ b/lib/pdf-generators.ts
@@ -301,12 +301,19 @@ export async function generateAndSaveInvoicePDF(params: GenerateInvoicePDFParams
     // Sauter une ligne
     clientYPosition += 4;
     
-    // Nom de la société en gras et police plus grande (utiliser company_name si disponible, sinon name)
-    const clientCompanyName = client.company_name || client.name;
-    if (clientCompanyName) {
+    // Nom juridique puis nom commercial (si différent)
+    const clientLegalName = client.company_name || client.name;
+    const clientCommercialName = client.name;
+    if (clientLegalName) {
       doc.setFontSize(11);
       doc.setFont('helvetica', 'bold');
-      doc.text(clientCompanyName, rightBoxX + 2, clientYPosition);
+      doc.text(clientLegalName, rightBoxX + 2, clientYPosition);
+      clientYPosition += 5;
+    }
+    if (clientCommercialName && clientCommercialName !== clientLegalName) {
+      doc.setFontSize(11);
+      doc.setFont('helvetica', 'bold');
+      doc.text(clientCommercialName, rightBoxX + 2, clientYPosition);
       clientYPosition += 5;
     }
     
@@ -836,11 +843,18 @@ export async function generateAndSaveStockReportPDF(params: GenerateStockReportP
     doc.setTextColor(0, 0, 0);
     clientYPosition += 4;
     
-    const clientCompanyName = client.company_name || client.name;
-    if (clientCompanyName) {
+    const clientLegalName = client.company_name || client.name;
+    const clientCommercialName = client.name;
+    if (clientLegalName) {
       doc.setFontSize(11);
       doc.setFont('helvetica', 'bold');
-      doc.text(clientCompanyName, rightBoxX + 2, clientYPosition);
+      doc.text(clientLegalName, rightBoxX + 2, clientYPosition);
+      clientYPosition += 5;
+    }
+    if (clientCommercialName && clientCommercialName !== clientLegalName) {
+      doc.setFontSize(11);
+      doc.setFont('helvetica', 'bold');
+      doc.text(clientCommercialName, rightBoxX + 2, clientYPosition);
       clientYPosition += 5;
     }
     
@@ -1523,11 +1537,18 @@ export async function generateAndSaveDepositSlipPDF(params: GenerateDepositSlipP
     doc.setTextColor(0, 0, 0);
     clientYPosition += 4;
     
-    const clientCompanyName = client.company_name || client.name;
-    if (clientCompanyName) {
+    const clientLegalName = client.company_name || client.name;
+    const clientCommercialName = client.name;
+    if (clientLegalName) {
       doc.setFontSize(11);
       doc.setFont('helvetica', 'bold');
-      doc.text(clientCompanyName, rightBoxX + 2, clientYPosition);
+      doc.text(clientLegalName, rightBoxX + 2, clientYPosition);
+      clientYPosition += 5;
+    }
+    if (clientCommercialName && clientCommercialName !== clientLegalName) {
+      doc.setFontSize(11);
+      doc.setFont('helvetica', 'bold');
+      doc.text(clientCommercialName, rightBoxX + 2, clientYPosition);
       clientYPosition += 5;
     }
     
@@ -2009,12 +2030,19 @@ export async function generateAndSaveCreditNotePDF(params: GenerateCreditNotePDF
     // Sauter une ligne
     clientYPosition += 4;
     
-    // Nom de la société en gras et police plus grande
-    const clientCompanyName = client.company_name || client.name;
-    if (clientCompanyName) {
+    // Nom juridique puis nom commercial (si différent)
+    const clientLegalName = client.company_name || client.name;
+    const clientCommercialName = client.name;
+    if (clientLegalName) {
       doc.setFontSize(11);
       doc.setFont('helvetica', 'bold');
-      doc.text(clientCompanyName, rightBoxX + 2, clientYPosition);
+      doc.text(clientLegalName, rightBoxX + 2, clientYPosition);
+      clientYPosition += 5;
+    }
+    if (clientCommercialName && clientCommercialName !== clientLegalName) {
+      doc.setFontSize(11);
+      doc.setFont('helvetica', 'bold');
+      doc.text(clientCommercialName, rightBoxX + 2, clientYPosition);
       clientYPosition += 5;
     }
     


### PR DESCRIPTION
- Updated the logic for displaying client names in PDF documents to differentiate between legal and commercial names.
- Renamed variables for clarity: `clientCompanyName` to `clientLegalName` and added `clientCommercialName`.
- Ensured that both names are displayed correctly when they differ, enhancing the accuracy of client information in generated PDFs.